### PR TITLE
🤔 remove `think` typo

### DIFF
--- a/content/extras.hbs
+++ b/content/extras.hbs
@@ -169,7 +169,7 @@ title: Extras
   </div>
 </div>
 
-<p>You can cover over this gaps by adding a think 1-pixel-wide stroke to the polygons.</p>
+<p>You can cover over this gaps by adding a 1-pixel-wide stroke to the polygons.</p>
 
 <div class="example">
   <div class="example__code">


### PR DESCRIPTION
This fixes a typo in the _One pixel gaps_ documentation. I believe the word `think` here was meant to be `thin` but the description works just as well by removing that word completely.