### PR TITLE
Fixes typo on modelling code example.

### DIFF
--- a/modules/docs/modeling-tutorial.hbs
+++ b/modules/docs/modeling-tutorial.hbs
@@ -507,7 +507,7 @@ translate: { x: 2, y: 1, z: 4.5 }
     });
     // leg on right
     leg.copyGraph({
-      translate: { x: -hipX },
+      translate: { x: hipX },
       rotate: { x: -TAU/8 },
     });
     ```

--- a/modules/docs/modeling-tutorial.hbs
+++ b/modules/docs/modeling-tutorial.hbs
@@ -531,7 +531,7 @@ translate: { x: 2, y: 1, z: 4.5 }
     });
     // leg on right
     let standLeg = leg.copy({
-      translate: { x: -hipX },
+      translate: { x: hipX },
       rotate: { x: -TAU/8 },
     });
     // stand foot


### PR DESCRIPTION
I believe I found a typo on the code example where both left and right legs are using `-hipX` which shows them stating from the same point:

![May-30-2019 17-19-40](https://user-images.githubusercontent.com/12223613/58647375-52dd0a80-82ff-11e9-97c9-eed54b8f3a61.gif)

Changing the value to positive positions the right leg correctly:

![May-30-2019 17-19-24](https://user-images.githubusercontent.com/12223613/58647352-3fca3a80-82ff-11e9-8908-3748257d3f0a.gif)
